### PR TITLE
docs: update definitions

### DIFF
--- a/content/docs/definitions.mdx
+++ b/content/docs/definitions.mdx
@@ -198,7 +198,7 @@ A curated index of artifacts (primitives, components, blocks, templates) with me
 Use this decision flow to name and place an artifact:
 
 1. Does it encapsulate a single behavior or a11y concern, with no styling? → **Primitive**
-2. Is it a reusable UI element that composes other elements and is styled? → **Component**
+2. Is it a styled, reusable UI element that adds visual design to primitives or composes multiple elements? → **Component**
 3. Does it solve a concrete product use case with opinionated composition and copy? → **Block**
 4. Does it scaffold a page/flow with routing/providers and replaceable regions? → **Template**
 5. Is it documentation of a recurring solution, independent of implementation? → **Pattern**


### PR DESCRIPTION
Made a few updates to `definitions`:

1. I removed the *Popularized by Radix UI* line.
2. Added Base UI to examples.
3. Fixed the formatting for Classification section.
4. Updated the line for components to mention _styled_.