### PR TITLE
fix: change Vercel's logo color in dark mode

### DIFF
--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -17,8 +17,8 @@ export default function Layout({ children }: LayoutProps<"/">) {
               width={24}
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>Ultracite</title>
-              <path d="M37.5274 0L75.0548 65H0L37.5274 0Z" fill="#000000" />
+              <title>Vercel</title>
+              <path d="M37.5274 0L75.0548 65H0L37.5274 0Z" fill="currentColor" />
             </svg>
             <span className="font-normal text-muted-foreground/50">/</span>
             <span className="font-medium">components.build</span>


### PR DESCRIPTION
Vercel's logo is not using the correct color in dark mode

<img width="229" height="50" alt="image" src="https://github.com/user-attachments/assets/55bb9472-9ff8-4762-9516-7d7a9418a3e6" />
<img width="229" height="50" alt="image" src="https://github.com/user-attachments/assets/f83d781d-0665-4cf5-b901-004987177dfe" />

