### PR TITLE
Change Dialog example's code comments

### DIFF
--- a/content/docs/composition.mdx
+++ b/content/docs/composition.mdx
@@ -208,13 +208,13 @@ For components with structured content areas, use semantic names that describe t
 
 ```tsx
 <DialogHeader>
-  {/* Form title */}
+  {/* Dialog title */}
 </DialogHeader>
 <DialogBody>
-  {/* Form content */}
+  {/* Dialog content */}
 </DialogBody>
 <DialogFooter>
-  {/* Form footer */}
+  {/* Dialog footer */}
 </DialogFooter>
 ```
 


### PR DESCRIPTION
Currently, the Dialog's code comments have "Form" as the example. Made a simple change so they now say "Dialog".