### PR TITLE
Add AI agent detection via @vercel/agent-readability

### DIFF
--- a/lib/md-tracking.ts
+++ b/lib/md-tracking.ts
@@ -1,14 +1,17 @@
+import type { DetectionMethod } from "@vercel/agent-readability";
 import { siteId } from "@/geistdocs";
 
 const PLATFORM_URL = "https://geistdocs.com/md-tracking";
 
 type TrackMdRequestParams = {
-  path: string;
-  userAgent: string | null;
-  referer: string | null;
   acceptHeader: string | null;
-  /** How the markdown was requested: 'md-url' for direct .md URLs, 'header-negotiated' for Accept header */
-  requestType?: "md-url" | "header-negotiated";
+  /** Detection method used to identify the agent (only for agent-rewrite requests) */
+  detectionMethod?: DetectionMethod | null;
+  path: string;
+  referer: string | null;
+  /** How the markdown was requested: 'md-url' for direct .md URLs, 'header-negotiated' for Accept header, 'agent-rewrite' for detected AI agents */
+  requestType?: "md-url" | "header-negotiated" | "agent-rewrite";
+  userAgent: string | null;
 };
 
 /**
@@ -21,6 +24,7 @@ export async function trackMdRequest({
   referer,
   acceptHeader,
   requestType,
+  detectionMethod,
 }: TrackMdRequestParams): Promise<void> {
   try {
     const response = await fetch(PLATFORM_URL, {
@@ -35,6 +39,7 @@ export async function trackMdRequest({
         referer,
         acceptHeader,
         requestType,
+        detectionMethod,
       }),
     });
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@orama/tokenizers": "^3.1.16",
     "@streamdown/cjk": "^1.0.1",
     "@streamdown/code": "^1.0.1",
+    "@vercel/agent-readability": "^0.2.1",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "ai": "^5.0.106",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@streamdown/code':
         specifier: ^1.0.1
         version: 1.0.1(react@19.2.4)
+      '@vercel/agent-readability':
+        specifier: ^0.2.1
+        version: 0.2.1(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -1972,6 +1975,16 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/agent-readability@0.2.1':
+    resolution: {integrity: sha512-ShT7BzIS/dwKompii8tm5do+NR1g4xL5M3wM7S01xsH6yuYQ7wiTPZEcmHMFLHCsAQg45/mD0hgrufpS3NVunw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      next: '>=14'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -5433,6 +5446,10 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/agent-readability@0.2.1(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    optionalDependencies:
+      next: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@vercel/analytics@1.6.1(next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
 } from "next/server";
 import { i18n } from "@/lib/geistdocs/i18n";
 import { trackMdRequest } from "@/lib/md-tracking";
+import { generateNotFoundMarkdown, isAIAgent } from "@vercel/agent-readability";
 
 const { rewrite: rewriteLLM } = rewritePath(
   "/*path",
@@ -54,6 +55,36 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
       return NextResponse.rewrite(new URL(result, request.nextUrl));
     }
   }
+
+  // AI agent detection — rewrite docs pages to markdown for agents
+  if (
+    (pathname === "/docs" || pathname.startsWith("/docs/")) &&
+    !pathname.includes("/llms.mdx/")
+  ) {
+    const agentResult = isAIAgent(request);
+    if (agentResult.detected && !isMarkdownPreferred(request)) {
+      const result = rewriteLLM(pathname);
+
+      if (result) {
+        context.waitUntil(
+          trackMdRequest({
+            path: pathname,
+            userAgent: request.headers.get("user-agent"),
+            referer: request.headers.get("referer"),
+            acceptHeader: request.headers.get("accept"),
+            requestType: "agent-rewrite",
+            detectionMethod: agentResult.method,
+          })
+        );
+        return NextResponse.rewrite(new URL(result, request.nextUrl));
+      }
+      // Agent requested a non-existent docs URL
+      return new NextResponse(generateNotFoundMarkdown(pathname), {
+        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+      });
+    }
+  }
+
 
   // Handle Accept header content negotiation and track the request
   if (isMarkdownPreferred(request)) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -76,12 +76,23 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
             detectionMethod: agentResult.method,
           })
         );
-        return NextResponse.rewrite(new URL(result, request.nextUrl));
+        const response = NextResponse.rewrite(new URL(result, request.nextUrl));
+        response.headers.set("Vary", "Accept");
+        return response;
       }
-      // Agent requested a non-existent docs URL
-      return new NextResponse(generateNotFoundMarkdown(pathname), {
-        headers: { "Content-Type": "text/markdown; charset=utf-8" },
-      });
+      // Agent requested a non-existent docs URL — return helpful markdown
+      return new NextResponse(
+        generateNotFoundMarkdown(pathname, {
+          sitemapUrl: "/sitemap.md",
+          indexUrl: "/llms.txt",
+        }),
+        {
+          headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            Vary: "Accept",
+          },
+        },
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `@vercel/agent-readability` package for AI agent detection in middleware
- Detected agents get markdown responses instead of HTML for better AI consumption
- Non-existent docs URLs return helpful not-found markdown with discovery links
- Accept header content negotiation continues to work as before

Matches the geistdocs template (vercel/geistdocs#58). Uses the same shared package as vercel/front#65649.

## Test plan
- [ ] AI agent hitting a valid docs URL gets markdown rewrite
- [ ] AI agent hitting a non-existent docs URL gets not-found markdown
- [ ] Normal browser requests unaffected
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)