### PR TITLE
Enforce dark theme with black background in GeistdocsProvider

### DIFF
--- a/app/styles/geistdocs.css
+++ b/app/styles/geistdocs.css
@@ -81,7 +81,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);

--- a/components/geistdocs/provider.tsx
+++ b/components/geistdocs/provider.tsx
@@ -50,6 +50,11 @@ export const GeistdocsProvider = ({
             SearchDialog: SearchDialogComponent,
             ...search,
           }}
+          theme={{
+            forcedTheme: "dark",
+            defaultTheme: "dark",
+            enableSystem: false,
+          }}
           {...props}
         />
       </TooltipProvider>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Intro
 description: components.build is an open-source standard for building modern, composable and accessible UI components.
 type: overview
 summary: An open standard co-authored by Hayden Bleasel and shadcn for building composable, accessible UI components for the modern web.


### PR DESCRIPTION
- Enforced dark mode as the default and mandatory theme via the GeistdocsProvider.
- Updated global CSS to set the dark mode background color to pure black.

[v0 Session](https://v0.app/chat/MGXwVs91tWJ)